### PR TITLE
Add license header for 4.2 support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 bl_info = {
     "name": "Custom Preferences Size",
     "author": "Rombout Versluijs, Pan Beep (Beep)",


### PR DESCRIPTION
Blenders' 4.2 update forces you to add this. I don't like it, so I just threw on a generic header for an MIT license. Change it to whatever you like, I don't think it cares what the actual license is.

Without it, it gives you this error:
`Missing manifest from: .../Custom-Preferences-Size-v001.zip`